### PR TITLE
Rtts sim listener

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,7 +1,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-#define ROBOT_COUNT 6
+#define ROBOT_COUNT 1
 
 #define MAX_ROBOT_COUNT 12 //dont change
 

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -161,6 +161,8 @@ public:
   DEF_VALUE(double,Double,Gravity)
   DEF_VALUE(std::string,String,VisionMulticastAddr)
   DEF_VALUE(int,Int,VisionMulticastPort)
+  DEF_VALUE(std::string,String,RttsMulticastAddr)
+  DEF_VALUE(int,Int,RttsMulticastPort)
   DEF_VALUE(int,Int,CommandListenPort)
   DEF_VALUE(int,Int,BlueStatusSendPort)
   DEF_VALUE(int,Int,YellowStatusSendPort)

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -70,6 +70,7 @@ public slots:
     void reconnectYellowStatusSocket();
     void reconnectBlueStatusSocket();
     void reconnectVisionSocket();
+    void reconnectRttsSocket();
     void recvActions();
 private:
     int getInterval();
@@ -96,6 +97,7 @@ private:
     GLWidgetGraphicsView *view;
     QSize lastSize;
     RoboCupSSLServer *visionServer;
+    RoboCupSSLServer *rttsServer;
     QUdpSocket *commandSocket;
     QUdpSocket *blueStatusSocket,*yellowStatusSocket;
 };

--- a/include/sslworld.h
+++ b/include/sslworld.h
@@ -86,6 +86,7 @@ public:
     dReal cursor_x,cursor_y,cursor_z;
     dReal cursor_radius;
     RoboCupSSLServer *visionServer;
+    RoboCupSSLServer *rttsServer;
     QUdpSocket *commandSocket;
     QUdpSocket *blueStatusSocket,*yellowStatusSocket;
     bool updatedCursor;

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -101,6 +101,8 @@ ConfigWidget::ConfigWidget()
   world.push_back(comm_vars);
     ADD_VALUE(comm_vars,String,VisionMulticastAddr,"224.5.23.2","Vision multicast address")  //SSL Vision: "224.5.23.2"
     ADD_VALUE(comm_vars,Int,VisionMulticastPort,10020,"Vision multicast port")
+    ADD_VALUE(comm_vars,String,RttsMulticastAddr,"224.5.23.2","Rtts multicast address")
+    ADD_VALUE(comm_vars,Int,RttsMulticastPort,-1,"Rtts multicast port")
     ADD_VALUE(comm_vars,Int,CommandListenPort,20011,"Command listen port")
     ADD_VALUE(comm_vars,Int,BlueStatusSendPort,30011,"Blue Team status send port")
     ADD_VALUE(comm_vars,Int,YellowStatusSendPort,30012,"Yellow Team status send port")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,6 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("grSim");
     QApplication a(argc, argv);
     MainWindow w;
-    w.show();
+    w.hide();
     return a.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -81,15 +81,18 @@ MainWindow::MainWindow(QWidget *parent)
     glwidget->resize(512,512);
 
     visionServer = NULL;
+    rttsServer = NULL;
     commandSocket = NULL;
     blueStatusSocket = NULL;
     yellowStatusSocket = NULL;
     reconnectVisionSocket();
+    reconnectRttsSocket();
     reconnectCommandSocket();
     reconnectBlueStatusSocket();
     reconnectYellowStatusSocket();
 
     glwidget->ssl->visionServer = visionServer;
+    glwidget->ssl->rttsServer = rttsServer;
     glwidget->ssl->commandSocket = commandSocket;
     glwidget->ssl->blueStatusSocket = blueStatusSocket;
     glwidget->ssl->yellowStatusSocket = yellowStatusSocket;
@@ -239,6 +242,8 @@ MainWindow::MainWindow(QWidget *parent)
     //network
     QObject::connect(configwidget->v_VisionMulticastAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectVisionSocket()));
     QObject::connect(configwidget->v_VisionMulticastPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectVisionSocket()));
+    QObject::connect(configwidget->v_RttsMulticastAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectRttsSocket()));
+    QObject::connect(configwidget->v_RttsMulticastPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectRttsSocket()));
     QObject::connect(configwidget->v_CommandListenPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectCommandSocket()));
     QObject::connect(configwidget->v_BlueStatusSendPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectBlueStatusSocket()));
     QObject::connect(configwidget->v_YellowStatusSendPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectYellowStatusSocket()));
@@ -389,6 +394,7 @@ void MainWindow::restartSimulator()
     glwidget->ssl = new SSLWorld(glwidget,glwidget->cfg,glwidget->forms[2],glwidget->forms[2]);
     glwidget->ssl->glinit();
     glwidget->ssl->visionServer = visionServer;
+    glwidget->ssl->rttsServer = rttsServer;
     glwidget->ssl->commandSocket = commandSocket;
     glwidget->ssl->blueStatusSocket = blueStatusSocket;
     glwidget->ssl->yellowStatusSocket = yellowStatusSocket;
@@ -522,6 +528,18 @@ void MainWindow::reconnectVisionSocket()
     visionServer->change_address(configwidget->VisionMulticastAddr());
     visionServer->change_port(configwidget->VisionMulticastPort());
     logStatus(QString("Vision server connected on: %1").arg(configwidget->VisionMulticastPort()),QColor("green"));
+}
+
+void MainWindow::reconnectRttsSocket()
+{
+    if(configwidget->RttsMulticastPort() != -1){
+        if (rttsServer == NULL) {
+            rttsServer = new RoboCupSSLServer(this);
+        }
+        rttsServer->change_address(configwidget->RttsMulticastAddr());
+        rttsServer->change_port(configwidget->RttsMulticastPort());
+        logStatus(QString("Rtts server connected on: %1").arg(configwidget->VisionMulticastPort()),QColor("green"));
+    }
 }
 
 void MainWindow::recvActions()

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -811,6 +811,9 @@ void SSLWorld::sendVisionBuffer()
         delete sendQueue.front();
         sendQueue.pop_front();
         visionServer->send(*packet);
+        if(rttsServer != NULL){
+            rttsServer->send(*packet);
+        }
         delete packet;
         if (sendQueue.isEmpty()) break;
     }


### PR DESCRIPTION
In order to connect the simulator to the front end of the webserver we could either change the port in the simulator and forward all messages to vision (which would cause a lot of unnecessary load on the server) or we could make a little alteration to grSim.

We chose for the second option and the feature can be seen in this branch. An additional RoboCupServer has been added which mimics the behaviour of the visionServer, but instead it will send the data additionally to another port (in our configuration 10037) where one of our python sockets will catch the data, transform it and forward it to the client.

The intention was to make the additional settings (rtts address and rtts port) completely optional. If these are not provided than grSim will ignore them and won't attempt to make an additional connection.

If this is not the actual behaviour than feedback and tips would be much appreciated.